### PR TITLE
temporary fix for installing pex-color with npm using github repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,12 @@
   "devDependencies": {
   },
   "dependencies": {
-    "pex-sys": "latest"
+    "pex-sys": "vorg/pex-sys"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/vorg/pex-color.git"
   },
   "bugs": "https://github.com/vorg/pex-color/issues",
-  "homepage": "https://github.com/vorg/pex-color.git",
   "license": "MIT"
 }


### PR DESCRIPTION
With this fix I have working pex-color using only package.json, using it from my github fork, and downloading pex-sys as dependency from your repo. This is a temporary solution, until pex is not on npm :)
